### PR TITLE
fixed crc.java

### DIFF
--- a/crc.java
+++ b/crc.java
@@ -64,7 +64,7 @@ class crc
 		for(int i=k;i<k+g-1;i++)
 		{	if(codewordR[i]!=0)
 			{	flag=1;
-				
+				break;
 			}
 			else
 				flag=0;


### PR DESCRIPTION
was missing a "break" on line 67;
this resulted in the program giving false positives when the last character of the received codeword is 0.
adding the break in the loop terminates at the first non-zero character and sets the flag to 1. this behaviour produces expected results.